### PR TITLE
Don't validate (tolerate missing information) in Entrez.read

### DIFF
--- a/genome_collector/mixins/NCBIMixin.py
+++ b/genome_collector/mixins/NCBIMixin.py
@@ -37,7 +37,7 @@ class NCBIMixin:
         # Do the request
 
         search = request(**kwargs)
-        return Entrez.read(search)
+        return Entrez.read(search, validate=False)
 
     def _get_taxid_genome_id_from_ncbi(self, taxid):
         """Return a Genome ID for this TaxID, provided by the NCBI API."""
@@ -104,7 +104,7 @@ class NCBIMixin:
                         "You will need to download the infos manually using "
                         "collection.download_taxid_genome_infos_from_ncbi("
                         "taxid, assembly_id=XXX) where assembly_id can be an "
-                        "ID, or an index of the form '#1' to select the first "
+                        "ID, or an index of the form '#0' to select the first "
                         "available assembly_id."
                     )
                 raise OSError(message)


### PR DESCRIPTION
One TaxID (can't share which) has incomplete AssemblyStatus information on NCBI which caused `Bio.Entrez.read()` to error. This MR adds `validate=False` to the function call so it will correctly run and return biopython records. With this MR, the taxid's records can be fetched as follows:

```python
col.download_taxid_genome_infos_from_ncbi(tax_id, assembly_id="#0")
records = col.get_taxid_biopython_records(tax_id, type='genomic_genbank')
```